### PR TITLE
Main

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -28,7 +28,7 @@ jobs:
                   submodules: recursive
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -86,7 +86,7 @@ jobs:
                   python -m build
 
             - name: Download artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v5
               with:
                   path: dist
                   merge-multiple: true

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 
@@ -76,7 +76,7 @@ jobs:
 
         steps:
             - name: Checkout source
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -86,7 +86,7 @@ jobs:
                   python -m build
 
             - name: Download artifact
-              uses: actions/download-artifact@v5
+              uses: actions/download-artifact@v6
               with:
                   path: dist
                   merge-multiple: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
                   submodules: recursive
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use newer versions of core actions for packaging and testing.

CI:
- Bump actions/checkout from v4 to v5 in packaging and test workflows.
- Bump actions/setup-python from v5 to v6 in packaging and test workflows.
- Bump actions/download-artifact from v4 to v6 in the PyPI packaging workflow.